### PR TITLE
Use HSQLDB as DB for dev env instead of Postgresql

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ dependencies {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
     testImplementation 'io.jmix.flowui:jmix-flowui-test-assist'
-    implementation 'org.postgresql:postgresql'
+    //implementation 'org.postgresql:postgresql'
+    runtimeOnly 'org.hsqldb:hsqldb'
 }
 
 test {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-main.datasource.url = jdbc:postgresql://localhost/jmixpm
-main.datasource.username = jmix
-main.datasource.password =jmix
+main.datasource.url = jdbc:hsqldb:file:.jmix/hsqldb/projectmanagement
+main.datasource.username = sa
+main.datasource.password =
 
 main.liquibase.change-log=com/company/jmixpm/liquibase/changelog.xml
 


### PR DESCRIPTION
`HSQLDB` doesn't need to run any other service to launch the project.

The same thing when we create a new project using `Intellij IDEA + Jmix`.